### PR TITLE
Update API key usage instructions and fix AscendUser naming typo

### DIFF
--- a/docs/src/content/docs/sdks/kotlin/quick-start.mdx
+++ b/docs/src/content/docs/sdks/kotlin/quick-start.mdx
@@ -21,7 +21,6 @@ class MyApplication : Application() {
 
         val httpConfig = HttpConfig(
             apiBaseUrl = "http://localhost:8100", // Replace with your actual API endpoint
-            headers = hashMapOf("api-key" to "project-api-key") // Replace with your actual API key
         )
 
         val experimentConfig = ExperimentConfig.Builder(object : IExperimentCallback {


### PR DESCRIPTION
## Description
This PR updates the documentation to reflect the correct SDK usage guidelines.

## Changes
- Removed instructions suggesting passing the API key directly in request headers.

## Reason for Change
These updates ensure the documentation reflects the correct integration approach and avoids misleading guidance.
